### PR TITLE
Remove _id from schema and fix model typings

### DIFF
--- a/src/models/allergen.schema.ts
+++ b/src/models/allergen.schema.ts
@@ -2,8 +2,7 @@ import { model, Schema, Types } from "mongoose";
 import { IAllergenSchema } from "./allergen.types";
 
 const allergenSchema = new Schema<IAllergenSchema>({
-  _id: Types.ObjectId,
   displayname: String
 });
 
-export const Allergen = model("Allergen", allergenSchema);
+export const Allergen = model<IAllergenSchema>("Allergen", allergenSchema);

--- a/src/models/comment.schema.ts
+++ b/src/models/comment.schema.ts
@@ -2,7 +2,6 @@ import { model, Schema, Types } from "mongoose";
 import { ICommentSchema } from "./comment.types";
 
 const commentSchema = new Schema<ICommentSchema>({
-  _id: Types.ObjectId,
   author: Types.ObjectId,
   flags: [Types.ObjectId],
   message: String,
@@ -10,4 +9,4 @@ const commentSchema = new Schema<ICommentSchema>({
   imgs: [Types.ObjectId]
 });
 
-export const Comment = model("Comment", commentSchema);
+export const Comment = model<ICommentSchema>("Comment", commentSchema);

--- a/src/models/image.schema.ts
+++ b/src/models/image.schema.ts
@@ -2,9 +2,8 @@ import { model, Schema, Types } from "mongoose";
 import { IImageSchema } from "./image.types";
 
 const imageSchema = new Schema<IImageSchema>({
-  _id: Types.ObjectId,
   hash: String,
   type: String
 });
 
-export const Image = model("Image", imageSchema);
+export const Image = model<IImageSchema>("Image", imageSchema);

--- a/src/models/ingredient.schema.ts
+++ b/src/models/ingredient.schema.ts
@@ -2,7 +2,6 @@ import { model, Schema, Types } from "mongoose";
 import { IIngredientSchema } from "./ingredient.types";
 
 const ingredientSchema = new Schema<IIngredientSchema>({
-  _id: Types.ObjectId,
   displayname: String,
   allergene: [Types.ObjectId],
   unit: Types.ObjectId,
@@ -10,4 +9,4 @@ const ingredientSchema = new Schema<IIngredientSchema>({
   reweLink: String
 });
 
-export const Ingredient = model("Ingredient", ingredientSchema);
+export const Ingredient = model<IIngredientSchema>("Ingredient", ingredientSchema);

--- a/src/models/recipe.schema.ts
+++ b/src/models/recipe.schema.ts
@@ -2,7 +2,6 @@ import { model, Schema, Types } from "mongoose";
 import { IRecipeSchema } from "./recipe.types";
 
 const recipeSchema = new Schema<IRecipeSchema>({
-  _id: Types.ObjectId,
   public: Boolean,
   flags: [Types.ObjectId],
   title: String,
@@ -28,4 +27,4 @@ const recipeSchema = new Schema<IRecipeSchema>({
   comments: [Types.ObjectId]
 });
 
-export const Recipe = model("Recipe", recipeSchema);
+export const Recipe = model<IRecipeSchema>("Recipe", recipeSchema);

--- a/src/models/unit.schema.ts
+++ b/src/models/unit.schema.ts
@@ -2,8 +2,7 @@ import { model, Schema, Types } from "mongoose";
 import { IUnitSchema } from "./unit.types";
 
 const unitSchema = new Schema<IUnitSchema>({
-  _id: Types.ObjectId,
   type: String
 });
 
-export const Unit = model("Unit", unitSchema);
+export const Unit = model<IUnitSchema>("Unit", unitSchema);

--- a/src/models/user.schema.ts
+++ b/src/models/user.schema.ts
@@ -2,7 +2,6 @@ import { model, Schema, Types } from "mongoose";
 import { IUserSchema } from "./user.types";
 
 const userSchema = new Schema<IUserSchema>({
-  _id: Types.ObjectId,
   created: Date,
   email: String,
   username: String,
@@ -10,4 +9,4 @@ const userSchema = new Schema<IUserSchema>({
   salt: String
 });
 
-export const User = model("User", userSchema);
+export const User = model<IUserSchema>("User", userSchema);


### PR DESCRIPTION
Removed _id from the schema because mongoose adds it:
![image](https://user-images.githubusercontent.com/16952802/95830424-f2a20980-0d37-11eb-9611-188b5632993d.png)

I also tested if the typings work, found that they don't, and fixed it.